### PR TITLE
Remove PyMC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,6 @@ USER root
 RUN apt-get update && apt-get install -y fonts-takao && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-### PyMC
-RUN conda install --quiet --yes pymc && \
-    conda install --quiet --yes -c conda-forge pymc3
-
 ### Prepare PIP
 RUN conda install --quiet --yes pip && \
     pip install --upgrade -I setuptools

--- a/sample-notebooks/00_Tools.ipynb
+++ b/sample-notebooks/00_Tools.ipynb
@@ -137,23 +137,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING (theano.configdefaults): install mkl with `conda install mkl-service`: No module named 'mkl'\n"
-     ]
-    }
-   ],
-   "source": [
-    "import pymc3"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
Remove PyMC because Python 3.7.3 (currently installed in jupyter/scipy-notebook) is unsupported by PyMC