### PR TITLE
Add magic for slack notification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,9 @@ USER $NB_USER
 RUN mkdir -p $HOME/.jupyter/custom/ && \
     cp /tmp/custom.css $HOME/.jupyter/custom/custom.css
 
+RUN mkdir -p $HOME/.ipython/profile_default/startup && \
+    cp /tmp/nbnotifier.py $HOME/.ipython/profile_default/startup/nbnotifier.py
+
 RUN mkdir -p $HOME/.local/share && \
     jupyter nbextensions_configurator enable --user && \
     jupyter contrib nbextension install --user && \

--- a/conf/nbnotifier.py
+++ b/conf/nbnotifier.py
@@ -1,0 +1,21 @@
+# https://reiyw.com/post/sending-notification-to-slack-from-jupyter-notebook/
+import json
+import os
+import socket
+
+from IPython.core.magic import register_line_magic
+import requests
+
+
+@register_line_magic
+def slack(line):
+    assert 'SLACK_WEBHOOKS_URL' in os.environ
+    webhooks_url = os.environ['SLACK_WEBHOOKS_URL']
+    sender = os.environ.get('SLACK_SENDER', socket.gethostname())
+    payload = {
+        'text':
+        line
+        if line else 'A cell that was running on *{}* has finished.'.format(
+            sender)
+    }
+    r = requests.post(webhooks_url, data=json.dumps(payload))


### PR DESCRIPTION
To enable slack notification, set the following environments:

* `SLACK_WEBHOOKS_URL` (Required) - Webhooks URL generated by https://slack.com/apps/A0F7XDUAZ-incoming-webhooks
* `SLACK_SENDER` (Optional) - Hostname or Name of Jupyter used for a notification message